### PR TITLE
fix for linker errors

### DIFF
--- a/cores/w806/Arduino.c
+++ b/cores/w806/Arduino.c
@@ -2,7 +2,7 @@
 #include "wm_hal.h"
 //#include "pins_arduino.h"
 
-// Массив таймеров
+// array of timers
 TIM_HandleTypeDef htim0;
 TIM_HandleTypeDef htim1;
 TIM_HandleTypeDef htim2;
@@ -10,6 +10,54 @@ TIM_HandleTypeDef htim3;
 TIM_HandleTypeDef htim4;
 TIM_HandleTypeDef htim5;
 
+const PIN_MAP pin_Map[] =
+{
+    { GPIOA, GPIO_PIN_0,    PA0,    MUX_PA0},
+    { GPIOA, GPIO_PIN_1,    PA1,    MUX_PA1},
+    { GPIOA, GPIO_PIN_2,    PA2,    MUX_PA2},
+    { GPIOA, GPIO_PIN_3,    PA3,    MUX_PA3},
+    { GPIOA, GPIO_PIN_4,    PA4,    MUX_PA4},
+    { GPIOA, GPIO_PIN_5,    PA5,    MUX_PA5},
+    { GPIOA, GPIO_PIN_6,    PA6,    MUX_PA6},
+    { GPIOA, GPIO_PIN_7,    PA7,    MUX_PA7},
+    { GPIOA, GPIO_PIN_8,    PA8,    MUX_PA8},
+    { GPIOA, GPIO_PIN_9,    PA9,    MUX_PA9},
+    { GPIOA, GPIO_PIN_10,   PA10,   MUX_PA10},
+    { GPIOA, GPIO_PIN_11,   PA11,   MUX_PA11},
+    { GPIOA, GPIO_PIN_12,   PA12,   MUX_PA12},
+    { GPIOA, GPIO_PIN_13,   PA13,   MUX_PA13},
+    { GPIOA, GPIO_PIN_14,   PA14,   MUX_PA14},
+    { GPIOA, GPIO_PIN_15,   PA15,   MUX_PA15},
+
+    { GPIOB, GPIO_PIN_0,    PB0,    MUX_PB0},
+    { GPIOB, GPIO_PIN_1,    PB1,    MUX_PB1},
+    { GPIOB, GPIO_PIN_2,    PB2,    MUX_PB2},
+    { GPIOB, GPIO_PIN_3,    PB3,    MUX_PB3},
+    { GPIOB, GPIO_PIN_4,    PB4,    MUX_PB4},
+    { GPIOB, GPIO_PIN_5,    PB5,    MUX_PB5},
+    { GPIOB, GPIO_PIN_6,    PB6,    MUX_PB6},
+    { GPIOB, GPIO_PIN_7,    PB7,    MUX_PB7},
+    { GPIOB, GPIO_PIN_8,    PB8,    MUX_PB8},
+    { GPIOB, GPIO_PIN_9,    PB9,    MUX_PB9},
+    { GPIOB, GPIO_PIN_10,   PB10,   MUX_PB10},
+    { GPIOB, GPIO_PIN_11,   PB11,   MUX_PB11},
+    { GPIOB, GPIO_PIN_12,   PB12,   MUX_PB12},
+    { GPIOB, GPIO_PIN_13,   PB13,   MUX_PB13},
+    { GPIOB, GPIO_PIN_14,   PB14,   MUX_PB14},
+    { GPIOB, GPIO_PIN_15,   PB15,   MUX_PB15},
+    { GPIOB, GPIO_PIN_16,   PB16,   MUX_PB16},
+    { GPIOB, GPIO_PIN_17,   PB17,   MUX_PB17},
+    { GPIOB, GPIO_PIN_18,   PB18,   MUX_PB18},
+    { GPIOB, GPIO_PIN_19,   PB19,   MUX_PB19},
+    { GPIOB, GPIO_PIN_20,   PB20,   MUX_PB20},
+    { GPIOB, GPIO_PIN_21,   PB21,   MUX_PB21}, 
+    { GPIOB, GPIO_PIN_22,   PB22,   MUX_PB22},
+    { GPIOB, GPIO_PIN_23,   PB23,   MUX_PB23},
+    { GPIOB, GPIO_PIN_24,   PB24,   MUX_PB24},
+    { GPIOB, GPIO_PIN_25,   PB25,   MUX_PB25}, 
+    { GPIOB, GPIO_PIN_26,   PB26,   MUX_PB26},
+    { GPIOB, GPIO_PIN_27,   PB27,   MUX_PB27}
+};
 
 
 // Массив для фиксации занятых каналов PWM
@@ -350,7 +398,3 @@ void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val)
 bool check_pin() {
 	return true;
 }
-
-// added for compatibility
-__attribute__((weak)) void yield() {}
-

--- a/cores/w806/Arduino.c
+++ b/cores/w806/Arduino.c
@@ -398,3 +398,7 @@ void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t val)
 bool check_pin() {
 	return true;
 }
+
+// added for compatibility
+__attribute__((weak)) void yield() {}
+

--- a/variants/air103/pins_arduino.h
+++ b/variants/air103/pins_arduino.h
@@ -14,10 +14,13 @@ enum pins
 };
 
 // Arduino style analog inputs
-#define A0  PA1
-#define A1  PA4
-#define A2  PA3
-#define A4  PA2
+#define A1  PA1
+#define A2  PA2
+#define A3  PA3
+#define A4  PA4
+
+// add A0 as alias to A1 for compatibility
+#define A0 A1
 
 // pin mux macros for W806
 #define MUX_PA0 (DIO)                       // Boot
@@ -25,8 +28,8 @@ enum pins
 #define MUX_PA2 (DIO | ADC4 | PWM0)
 #define MUX_PA3 (DIO | ADC3 | PWM1)
 #define MUX_PA4 (DIO | ADC2 | PWM4)         // JTAG_SWO
-#define MUX_PA5 (DIO)                       // not connected on PCB
-#define MUX_PA6 (DIO)                       // not connected on PCB
+#define MUX_PA5 (NONE)                       // not connected on PCB
+#define MUX_PA6 (NONE)                       // not connected on PCB
 #define MUX_PA7 (DIO | PWM4 | _SPI_MOSI)
 #define MUX_PA8 (DIO)
 #define MUX_PA9 (DIO)
@@ -58,12 +61,12 @@ enum pins
 #define MUX_PB18 (DIO)
 #define MUX_PB19 (NONE) // TX0: used to download firmware and output to console
 #define MUX_PB20 (NONE) // RX0: debug data via printf()
-#define MUX_PB21 (DIO)                      // not connected on PCB
-#define MUX_PB22 (DIO)                      // not connected on PCB
+#define MUX_PB21 (NONE)                     // not connected on PCB
+#define MUX_PB22 (NONE)                     // not connected on PCB
 #define MUX_PB23 (NONE)                     // no pin for PB23 on W806 package
-#define MUX_PB24 (DIO | PWM2 | _SPI_SCK)    // only connected to LED_BUILTIN_1
-#define MUX_PB25 (DIO | PWM3 | _SPI_MISO)   // only connected to LED_BUILTIN_2
-#define MUX_PB26 (DIO | PWM4 | _SPI_MOSI)   // only connected to LED_BUILTIN_3
+#define MUX_PB24 (DIO | PWM2)               // only connected to LED_BUILTIN_1
+#define MUX_PB25 (DIO | PWM3)               // only connected to LED_BUILTIN_2
+#define MUX_PB26 (DIO | PWM4)               // only connected to LED_BUILTIN_3
 #define MUX_PB27 (DIO)                      // only connected to PSRAM CS
 
 extern const PIN_MAP pin_Map[];

--- a/variants/air103/pins_arduino.h
+++ b/variants/air103/pins_arduino.h
@@ -1,77 +1,72 @@
-// Описание выводов для платы Air103
+// pin description for Air103 board
 #ifndef Pins_Arduino_h
 #define Pins_Arduino_h
 
 #include "./include/driver/wm_hal.h"
 #include <GPIO_defs.h>
 
-
-
-
-// Перечисление выводов - индекс массива возможных альтернатив 
-
+// pin enum - index of an array of possible alternatives
 enum pins 
-{PA0,PA1,PA2,PA3,PA4,PA5,PA6,PA7,PA8,PA9,PA10,PA11,PA12,PA13,PA14,PA15,
- PB0,PB1,PB2,PB3,PB4,PB5,PB6,PB7,PB8,PB9,PB10,PB11,PB12,PB13,PB14,PB15,PB16,PB17,PB18,PB19,PB20,PB21,PB22,PB23,PB24,PB25,PB26,PB27};
-
-// Arduino macros for analog inputs
-#define A1 PA1
-#define A2 PA2
-#define A3 PA3
-#define A4 PA4
-
-// add A0 as alias to A1 for compatibility
-#define A0 A1
-
-
-const PIN_MAP pin_Map[] = {
-    { GPIOA, GPIO_PIN_0,	PA0,	NONE},      // Отсутствует на плате
-    { GPIOA, GPIO_PIN_1,	PA1,	DIO|ADC1},	// JTAG_CK
-    { GPIOA, GPIO_PIN_2,	PA2,	DIO|ADC4|PWM0},
-    { GPIOA, GPIO_PIN_3,	PA3,	DIO|ADC3|PWM1},
-    { GPIOA, GPIO_PIN_4,	PA4,	DIO|ADC2},	// JTAG_SWO
-    { GPIOA, GPIO_PIN_5,	PA5,	NONE},      // Отсутствует на плате
-    { GPIOA, GPIO_PIN_6,	PA6,	NONE},      // Отсутствует на плате
-    { GPIOA, GPIO_PIN_7,	PA7,	DIO|PWM4|_SPI_MOSI},
-    { GPIOA, GPIO_PIN_8,	PA8,	DIO},
-    { GPIOA, GPIO_PIN_9,	PA9,	DIO},
-    { GPIOA, GPIO_PIN_10,	PA10,	DIO|PWM0},
-    { GPIOA, GPIO_PIN_11,	PA11,	DIO|PWM1},       
-    { GPIOA, GPIO_PIN_12,	PA12,	DIO|PWM2},
-    { GPIOA, GPIO_PIN_13,	PA13,	DIO|PWM3},    
-    { GPIOA, GPIO_PIN_14,	PA14,	DIO|PWM4},
-    { GPIOA, GPIO_PIN_15,	PA15,	DIO},       // нет пина, PSRAM SCLK
-
-    { GPIOB, GPIO_PIN_0,	PB0,	DIO|PWM0|_SPI_MISO},
-    { GPIOB, GPIO_PIN_1,	PB1,	DIO|PWM1|_SPI_SCK},
-    { GPIOB, GPIO_PIN_2,	PB2,	DIO|PWM2|_SPI_SCK},
-    { GPIOB, GPIO_PIN_3,	PB3,	DIO|PWM3|_SPI_MISO},
-    { GPIOB, GPIO_PIN_4,	PB4,	DIO|_SPI_SS},
-    { GPIOB, GPIO_PIN_5,	PB5,	DIO|_SPI_MOSI},
-    { GPIOB, GPIO_PIN_6,	PB6,	DIO},
-    { GPIOB, GPIO_PIN_7,	PB7,	DIO},
-    { GPIOB, GPIO_PIN_8,	PB8,	DIO},
-    { GPIOB, GPIO_PIN_9,	PB9,	DIO},
-    { GPIOB, GPIO_PIN_10,	PB10,	DIO},
-    { GPIOB, GPIO_PIN_11,	PB11,	DIO},       
-    { GPIOB, GPIO_PIN_12,	PB12,	DIO|PWM0},
-    { GPIOB, GPIO_PIN_13,	PB13,	DIO|PWM1},    
-    { GPIOB, GPIO_PIN_14,	PB14,	DIO|PWM2|_SPI_SS},
-    { GPIOB, GPIO_PIN_15,	PB15,	DIO|PWM3|_SPI_SCK},             
-    { GPIOB, GPIO_PIN_16,	PB16,	DIO|_SPI_MISO},
-    { GPIOB, GPIO_PIN_17,	PB17,	DIO|_SPI_MOSI},       
-    { GPIOB, GPIO_PIN_18,	PB18,	DIO},
-    { GPIOB, GPIO_PIN_19,	PB19,	NONE},	    // TX0 |Используется для загрузки прошивки и вывода на консоль
-    { GPIOB, GPIO_PIN_20,	PB20,	NONE},		  // RX0 |отладочных данных через printf()
-    { GPIOB, GPIO_PIN_21,	PB21,	NONE},      // Отсутствует на плате 
-    { GPIOB, GPIO_PIN_22,	PB22,	NONE},      // Отсутствует на плате 
-    { GPIOB, GPIO_PIN_23,	PB23,	NONE},      // Отсутствует на плате 
-    { GPIOB, GPIO_PIN_24,	PB24,	DIO|PWM2},  // нет пина, LED
-    { GPIOB, GPIO_PIN_25,	PB25,	DIO|PWM3},  // нет пина, LED
-    { GPIOB, GPIO_PIN_26,	PB26,	DIO|PWM4},  // нет пина, LED
-    { GPIOB, GPIO_PIN_27,	PB27,	DIO}        // нет пина, PSRAM CS
+{
+  PA0,PA1,PA2,PA3,PA4,PA5,PA6,PA7,PA8,PA9,PA10,PA11,PA12,PA13,PA14,PA15,
+  PB0,PB1,PB2,PB3,PB4,PB5,PB6,PB7,PB8,PB9,PB10,PB11,PB12,PB13,PB14,PB15,
+  PB16,PB17,PB18,PB19,PB20,PB21,PB22,PB23,PB24,PB25,PB26,PB27
 };
 
+// Arduino style analog inputs
+#define A0  PA1
+#define A1  PA4
+#define A2  PA3
+#define A4  PA2
+
+// pin mux macros for W806
+#define MUX_PA0 (DIO)                       // Boot
+#define MUX_PA1 (DIO | ADC1 | PWM3)         // JTAG_CK
+#define MUX_PA2 (DIO | ADC4 | PWM0)
+#define MUX_PA3 (DIO | ADC3 | PWM1)
+#define MUX_PA4 (DIO | ADC2 | PWM4)         // JTAG_SWO
+#define MUX_PA5 (DIO)                       // not connected on PCB
+#define MUX_PA6 (DIO)                       // not connected on PCB
+#define MUX_PA7 (DIO | PWM4 | _SPI_MOSI)
+#define MUX_PA8 (DIO)
+#define MUX_PA9 (DIO)
+#define MUX_PA10 (DIO | PWM0)
+#define MUX_PA11 (DIO | PWM1)
+#define MUX_PA12 (DIO | PWM2)
+#define MUX_PA13 (DIO | PWM3)
+#define MUX_PA14 (DIO | PWM4)
+#define MUX_PA15 (DIO)                      // only connected to PSRAM SCLK
+
+#define MUX_PB0 (DIO | PWM0 | _SPI_MISO)
+#define MUX_PB1 (DIO | PWM1 | _SPI_SCK)
+#define MUX_PB2 (DIO | PWM2 | _SPI_SCK)     // connected to PSRAM SI/SIO0
+#define MUX_PB3 (DIO | PWM3 | _SPI_MISO)    // connected to PSRAM SI/SIO1
+#define MUX_PB4 (DIO | _SPI_SS)             // connected to PSRAM SI/SIO2
+#define MUX_PB5 (DIO | _SPI_MOSI)           // connected to PSRAM SI/SIO4
+#define MUX_PB6 (DIO)
+#define MUX_PB7 (DIO)
+#define MUX_PB8 (DIO)
+#define MUX_PB9 (DIO)
+#define MUX_PB10 (DIO)
+#define MUX_PB11 (DIO)
+#define MUX_PB12 (DIO | PWM0)
+#define MUX_PB13 (DIO | PWM1)
+#define MUX_PB14 (DIO | PWM2 | _SPI_SS)     // PIN_SPI_SS
+#define MUX_PB15 (DIO | PWM3 | _SPI_SCK)    // PIN_SPI_SCK
+#define MUX_PB16 (DIO | _SPI_MISO)          // PIN_SPI_MISO
+#define MUX_PB17 (DIO | _SPI_MOSI)          // PIN_SPI_MOSI
+#define MUX_PB18 (DIO)
+#define MUX_PB19 (NONE) // TX0: used to download firmware and output to console
+#define MUX_PB20 (NONE) // RX0: debug data via printf()
+#define MUX_PB21 (DIO)                      // not connected on PCB
+#define MUX_PB22 (DIO)                      // not connected on PCB
+#define MUX_PB23 (NONE)                     // no pin for PB23 on W806 package
+#define MUX_PB24 (DIO | PWM2 | _SPI_SCK)    // only connected to LED_BUILTIN_1
+#define MUX_PB25 (DIO | PWM3 | _SPI_MISO)   // only connected to LED_BUILTIN_2
+#define MUX_PB26 (DIO | PWM4 | _SPI_MOSI)   // only connected to LED_BUILTIN_3
+#define MUX_PB27 (DIO)                      // only connected to PSRAM CS
+
+extern const PIN_MAP pin_Map[];
 
 // Additional board settings
 #include "variant.h"

--- a/variants/air103/variant.h
+++ b/variants/air103/variant.h
@@ -11,8 +11,8 @@
 #define PIN_SPI_MISO  (PB16)
 #define PIN_SPI_MOSI  (PB17)
 
-#define PINS_COUNT          (44U)           // Количество выводов на плате. Выводы PB19,PB20,PB23 не используются
-#define ADC_COUNT           (4U)            // Количество каналов АЦП
-#define PWM_COUNT           (5U)            // Количество каналов ШИМ
+#define PINS_COUNT  (44U) // pins in total, PA5, PA6, PB19, PB20, PB21, PB22 and PB23 are not used
+#define ADC_COUNT   (4U)  // number of ADC channels
+#define PWM_COUNT   (5U)  // number of PWM channels
 
 #endif /* _VARIANT_ARDUINO_Air103_ */

--- a/variants/w801/pins_arduino.h
+++ b/variants/w801/pins_arduino.h
@@ -1,74 +1,72 @@
-// Описание выводов для платы w801
+// pin description for W801 board
 #ifndef Pins_Arduino_h
 #define Pins_Arduino_h
 
 #include "./include/driver/wm_hal.h"
 #include <GPIO_defs.h>
 
-
-// Перечисление выводов - индекс массива возможных альтернатив 
-
+// pin enum - index of an array of possible alternatives
 enum pins 
-{PA0,PA1,PA2,PA3,PA4,PA5,PA6,PA7,PA8,PA9,PA10,PA11,PA12,PA13,PA14,PA15,
- PB0,PB1,PB2,PB3,PB4,PB5,PB6,PB7,PB8,PB9,PB10,PB11,PB12,PB13,PB14,PB15,PB16,PB17,PB18,PB19,PB20,PB21,PB22,PB23,PB24,PB25,PB26,PB27};
-
-// Arduino macros for analog inputs
-#define A1 PA1
-#define A2 PA2
-#define A3 PA3
-#define A4 PA4
-
-// add A0 as alias to A1 for compatibility
-#define A0 A1
-
-
-const PIN_MAP pin_Map[] = {
-    { GPIOA, GPIO_PIN_0,	PA0,	NONE},          // Отсутствует на плате 
-    { GPIOA, GPIO_PIN_1,	PA1,	DIO|ADC1|PWM3},	// JTAG_CK
-    { GPIOA, GPIO_PIN_2,	PA2,	DIO|ADC4|PWM0},
-    { GPIOA, GPIO_PIN_3,	PA3,	DIO|ADC3|PWM1},
-    { GPIOA, GPIO_PIN_4,	PA4,	DIO|ADC2|PWM4},	// JTAG_SWO
-    { GPIOA, GPIO_PIN_5,	PA5,	DIO},
-    { GPIOA, GPIO_PIN_6,	PA6,	DIO},
-    { GPIOA, GPIO_PIN_7,	PA7,	DIO|PWM4|_SPI_MOSI},
-    { GPIOA, GPIO_PIN_8,	PA8,	DIO},
-    { GPIOA, GPIO_PIN_9,	PA9,	DIO},
-    { GPIOA, GPIO_PIN_10,	PA10,	DIO|PWM0},
-    { GPIOA, GPIO_PIN_11,	PA11,	DIO|PWM1},       
-    { GPIOA, GPIO_PIN_12,	PA12,	DIO|PWM2},
-    { GPIOA, GPIO_PIN_13,	PA13,	DIO|PWM3},    
-    { GPIOA, GPIO_PIN_14,	PA14,	DIO|PWM4},
-    { GPIOA, GPIO_PIN_15,	PA15,	DIO},             
-
-    { GPIOB, GPIO_PIN_0,	PB0,	DIO|PWM0|_SPI_MISO},
-    { GPIOB, GPIO_PIN_1,	PB1,	DIO|PWM1|_SPI_SCK},
-    { GPIOB, GPIO_PIN_2,	PB2,	DIO|PWM2|_SPI_SCK},
-    { GPIOB, GPIO_PIN_3,	PB3,	DIO|PWM3|_SPI_MISO},
-    { GPIOB, GPIO_PIN_4,	PB4,	DIO|_SPI_SS},
-    { GPIOB, GPIO_PIN_5,	PB5,	DIO|_SPI_MOSI},
-    { GPIOB, GPIO_PIN_6,	PB6,	DIO},
-    { GPIOB, GPIO_PIN_7,	PB7,	DIO},
-    { GPIOB, GPIO_PIN_8,	PB8,	DIO},
-    { GPIOB, GPIO_PIN_9,	PB9,	DIO},
-    { GPIOB, GPIO_PIN_10,	PB10,	DIO},
-    { GPIOB, GPIO_PIN_11,	PB11,	DIO},       
-    { GPIOB, GPIO_PIN_12,	PB12,	DIO|PWM0},
-    { GPIOB, GPIO_PIN_13,	PB13,	DIO|PWM1},    
-    { GPIOB, GPIO_PIN_14,	PB14,	DIO|PWM2|_SPI_SS},
-    { GPIOB, GPIO_PIN_15,	PB15,	DIO|PWM3|_SPI_SCK},             
-    { GPIOB, GPIO_PIN_16,	PB16,	DIO|_SPI_MISO},
-    { GPIOB, GPIO_PIN_17,	PB17,	DIO|_SPI_MOSI},       
-    { GPIOB, GPIO_PIN_18,	PB18,	DIO},
-    { GPIOB, GPIO_PIN_19,	PB19,	NONE},	    // TX0 |Используется для загрузки прошивки и вывода на консоль
-    { GPIOB, GPIO_PIN_20,	PB20,	NONE},		  // RX0 |отладочных данных через printf()
-    { GPIOB, GPIO_PIN_21,	PB21,	DIO}, 
-    { GPIOB, GPIO_PIN_22,	PB22,	DIO},
-    { GPIOB, GPIO_PIN_23,	PB23,	DIO|_SPI_SS},    
-    { GPIOB, GPIO_PIN_24,	PB24,	DIO|PWM2|_SPI_SCK},
-    { GPIOB, GPIO_PIN_25,	PB25,	DIO|PWM3|_SPI_MISO}, 
-    { GPIOB, GPIO_PIN_26,	PB26,	DIO|PWM4|_SPI_MOSI},
-    { GPIOB, GPIO_PIN_27,	PB27,	DIO}
+{
+  PA0,PA1,PA2,PA3,PA4,PA5,PA6,PA7,PA8,PA9,PA10,PA11,PA12,PA13,PA14,PA15,
+  PB0,PB1,PB2,PB3,PB4,PB5,PB6,PB7,PB8,PB9,PB10,PB11,PB12,PB13,PB14,PB15,
+  PB16,PB17,PB18,PB19,PB20,PB21,PB22,PB23,PB24,PB25,PB26,PB27
 };
+
+// Arduino style analog inputs
+#define A0  PA1
+#define A1  PA4
+#define A2  PA3
+#define A4  PA2
+
+// pin mux macros for W801
+#define MUX_PA0 (DIO)                       // Boot
+#define MUX_PA1 (DIO | ADC1 | PWM3)         // JTAG_CK
+#define MUX_PA2 (DIO | ADC4 | PWM0)
+#define MUX_PA3 (DIO | ADC3 | PWM1)
+#define MUX_PA4 (DIO | ADC2 | PWM4)         // JTAG_SWO
+#define MUX_PA5 (DIO)
+#define MUX_PA6 (DIO)
+#define MUX_PA7 (DIO | PWM4 | _SPI_MOSI)
+#define MUX_PA8 (DIO)
+#define MUX_PA9 (DIO)
+#define MUX_PA10 (DIO | PWM0)
+#define MUX_PA11 (DIO | PWM1)
+#define MUX_PA12 (DIO | PWM2)
+#define MUX_PA13 (DIO | PWM3)
+#define MUX_PA14 (DIO | PWM4)
+#define MUX_PA15 (DIO)
+
+#define MUX_PB0 (DIO | PWM0 | _SPI_MISO)
+#define MUX_PB1 (DIO | PWM1 | _SPI_SCK)
+#define MUX_PB2 (DIO | PWM2 | _SPI_SCK)
+#define MUX_PB3 (DIO | PWM3 | _SPI_MISO)
+#define MUX_PB4 (DIO | _SPI_SS)
+#define MUX_PB5 (DIO | _SPI_MOSI)           // LED_BUILTIN_1
+#define MUX_PB6 (DIO)
+#define MUX_PB7 (DIO)
+#define MUX_PB8 (DIO)
+#define MUX_PB9 (DIO)
+#define MUX_PB10 (DIO)
+#define MUX_PB11 (DIO)                      // LED_BUILTIN_7
+#define MUX_PB12 (DIO | PWM0)
+#define MUX_PB13 (DIO | PWM1)
+#define MUX_PB14 (DIO | PWM2 | _SPI_SS)     // PIN_SPI_SS
+#define MUX_PB15 (DIO | PWM3 | _SPI_SCK)    // PIN_SPI_SCK
+#define MUX_PB16 (DIO | _SPI_MISO)          // PIN_SPI_MISO / LED_BUILTIN_6
+#define MUX_PB17 (DIO | _SPI_MOSI)          // PIN_SPI_MOSI / LED_BUILTIN_5
+#define MUX_PB18 (DIO)                      // LED_BUILTIN_4
+#define MUX_PB19 (NONE) // TX0: used to download firmware and output to console
+#define MUX_PB20 (NONE) // RX0: debug data via printf()
+#define MUX_PB21 (DIO)
+#define MUX_PB22 (DIO)
+#define MUX_PB23 (DIO | _SPI_SS)
+#define MUX_PB24 (DIO | PWM2 | _SPI_SCK)
+#define MUX_PB25 (DIO | PWM3 | _SPI_MISO)   // LED_BUILTIN_2
+#define MUX_PB26 (DIO | PWM4 | _SPI_MOSI)   // LED_BUILTIN_3
+#define MUX_PB27 (DIO)
+
+extern const PIN_MAP pin_Map[];
 
 // Additional board settings
 #include "variant.h"

--- a/variants/w801/pins_arduino.h
+++ b/variants/w801/pins_arduino.h
@@ -13,11 +13,14 @@ enum pins
   PB16,PB17,PB18,PB19,PB20,PB21,PB22,PB23,PB24,PB25,PB26,PB27
 };
 
-// Arduino style analog inputs
-#define A0  PA1
-#define A1  PA4
-#define A2  PA3
-#define A4  PA2
+// Arduino macros for analog inputs
+#define A1 PA1
+#define A2 PA2
+#define A3 PA3
+#define A4 PA4
+
+// add A0 as alias to A1 for compatibility
+#define A0 A1
 
 // pin mux macros for W801
 #define MUX_PA0 (DIO)                       // Boot

--- a/variants/w801/variant.h
+++ b/variants/w801/variant.h
@@ -15,10 +15,8 @@
 #define PIN_SPI_MISO  (PB16)
 #define PIN_SPI_MOSI  (PB17)
 
+#define PINS_COUNT  (44U) // pins in total, PB19, PB20 and PB23 are not used
+#define ADC_COUNT   (4U)  // number of ADC channels
+#define PWM_COUNT   (5U)  // number of PWM channels
 
-#define PINS_COUNT          (44U)           // Количество выводов на плате. Выводы PB19,PB20,PB23 не используются
-#define ADC_COUNT           (4U)            // Количество каналов АЦП
-#define PWM_COUNT           (5U)            // Количество каналов ШИМ
-
-
-#endif /* _VARIANT_ARDUINO_Air103_ */
+#endif /* _VARIANT_ARDUINO_W801_ */

--- a/variants/w806/pins_arduino.h
+++ b/variants/w806/pins_arduino.h
@@ -1,77 +1,72 @@
-// Описание выводов для платы HLK-W806-KIT
+// pin description for HLK-W806-KIT board
 #ifndef Pins_Arduino_h
 #define Pins_Arduino_h
 
 #include "./include/driver/wm_hal.h"
 #include <GPIO_defs.h>
 
-
-
-
-// Перечисление выводов - индекс массива возможных альтернатив 
-
+// pin enum - index of an array of possible alternatives
 enum pins 
-{PA0,PA1,PA2,PA3,PA4,PA5,PA6,PA7,PA8,PA9,PA10,PA11,PA12,PA13,PA14,PA15,
- PB0,PB1,PB2,PB3,PB4,PB5,PB6,PB7,PB8,PB9,PB10,PB11,PB12,PB13,PB14,PB15,PB16,PB17,PB18,PB19,PB20,PB21,PB22,PB23,PB24,PB25,PB26,PB27};
-
-// Arduino macros for analog inputs
-#define A1 PA1
-#define A2 PA2
-#define A3 PA3
-#define A4 PA4
-
-// add A0 as alias to A1 for compatibility
-#define A0 A1
-
-
-
-const PIN_MAP pin_Map[] = {
-    { GPIOA, GPIO_PIN_0,	PA0,	DIO|PWM2|_SPI_SS},
-    { GPIOA, GPIO_PIN_1,	PA1,	DIO|ADC1|PWM3},	// JTAG_CK
-    { GPIOA, GPIO_PIN_2,	PA2,	DIO|ADC4|PWM0},
-    { GPIOA, GPIO_PIN_3,	PA3,	DIO|ADC3|PWM1},
-    { GPIOA, GPIO_PIN_4,	PA4,	DIO|ADC2|PWM4},	// JTAG_SWO
-    { GPIOA, GPIO_PIN_5,	PA5,	DIO},
-    { GPIOA, GPIO_PIN_6,	PA6,	DIO},
-    { GPIOA, GPIO_PIN_7,	PA7,	DIO|PWM4|_SPI_MOSI},
-    { GPIOA, GPIO_PIN_8,	PA8,	DIO},
-    { GPIOA, GPIO_PIN_9,	PA9,	DIO},
-    { GPIOA, GPIO_PIN_10,	PA10,	DIO|PWM0},
-    { GPIOA, GPIO_PIN_11,	PA11,	DIO|PWM1},       
-    { GPIOA, GPIO_PIN_12,	PA12,	DIO|PWM2},
-    { GPIOA, GPIO_PIN_13,	PA13,	DIO|PWM3},    
-    { GPIOA, GPIO_PIN_14,	PA14,	DIO|PWM4},
-    { GPIOA, GPIO_PIN_15,	PA15,	DIO},             
-
-    { GPIOB, GPIO_PIN_0,	PB0,	DIO|PWM0|_SPI_MISO},
-    { GPIOB, GPIO_PIN_1,	PB1,	DIO|PWM1|_SPI_SCK},
-    { GPIOB, GPIO_PIN_2,	PB2,	DIO|PWM2|_SPI_SCK},
-    { GPIOB, GPIO_PIN_3,	PB3,	DIO|PWM3|_SPI_MISO},
-    { GPIOB, GPIO_PIN_4,	PB4,	DIO|_SPI_SS},
-    { GPIOB, GPIO_PIN_5,	PB5,	DIO|_SPI_MOSI},
-    { GPIOB, GPIO_PIN_6,	PB6,	DIO},
-    { GPIOB, GPIO_PIN_7,	PB7,	DIO},
-    { GPIOB, GPIO_PIN_8,	PB8,	DIO},
-    { GPIOB, GPIO_PIN_9,	PB9,	DIO},
-    { GPIOB, GPIO_PIN_10,	PB10,	DIO},
-    { GPIOB, GPIO_PIN_11,	PB11,	DIO},       
-    { GPIOB, GPIO_PIN_12,	PB12,	DIO|PWM0},
-    { GPIOB, GPIO_PIN_13,	PB13,	DIO|PWM1},    
-    { GPIOB, GPIO_PIN_14,	PB14,	DIO|PWM2|_SPI_SS},
-    { GPIOB, GPIO_PIN_15,	PB15,	DIO|PWM3|_SPI_SCK},             
-    { GPIOB, GPIO_PIN_16,	PB16,	DIO|_SPI_MISO},
-    { GPIOB, GPIO_PIN_17,	PB17,	DIO|_SPI_MOSI},       
-    { GPIOB, GPIO_PIN_18,	PB18,	DIO},
-    { GPIOB, GPIO_PIN_19,	PB19,	NONE},	    // TX0 |Используется для загрузки прошивки и вывода на консоль
-    { GPIOB, GPIO_PIN_20,	PB20,	NONE},		// RX0 |отладочных данных через printf()
-    { GPIOB, GPIO_PIN_21,	PB21,	DIO}, 
-    { GPIOB, GPIO_PIN_22,	PB22,	DIO},
-    { GPIOB, GPIO_PIN_23,	PB23,	NONE},      // Отсутствует на плате    
-    { GPIOB, GPIO_PIN_24,	PB24,	DIO|PWM2|_SPI_SCK},
-    { GPIOB, GPIO_PIN_25,	PB25,	DIO|PWM3|_SPI_MISO}, 
-    { GPIOB, GPIO_PIN_26,	PB26,	DIO|PWM4|_SPI_MOSI},
-    { GPIOB, GPIO_PIN_27,	PB27,	DIO}
+{
+  PA0,PA1,PA2,PA3,PA4,PA5,PA6,PA7,PA8,PA9,PA10,PA11,PA12,PA13,PA14,PA15,
+  PB0,PB1,PB2,PB3,PB4,PB5,PB6,PB7,PB8,PB9,PB10,PB11,PB12,PB13,PB14,PB15,
+  PB16,PB17,PB18,PB19,PB20,PB21,PB22,PB23,PB24,PB25,PB26,PB27
 };
+
+// Arduino style analog inputs
+#define A0  PA1
+#define A1  PA4
+#define A2  PA3
+#define A4  PA2
+
+// pin mux macros for W806
+#define MUX_PA0 (DIO | PWM2 | _SPI_SS)      // Boot
+#define MUX_PA1 (DIO | ADC1 | PWM3)         // JTAG_CK
+#define MUX_PA2 (DIO | ADC4 | PWM0)
+#define MUX_PA3 (DIO | ADC3 | PWM1)
+#define MUX_PA4 (DIO | ADC2 | PWM4)         // JTAG_SWO
+#define MUX_PA5 (DIO)
+#define MUX_PA6 (DIO)
+#define MUX_PA7 (DIO | PWM4 | _SPI_MOSI)
+#define MUX_PA8 (DIO)
+#define MUX_PA9 (DIO)
+#define MUX_PA10 (DIO | PWM0)
+#define MUX_PA11 (DIO | PWM1)
+#define MUX_PA12 (DIO | PWM2)
+#define MUX_PA13 (DIO | PWM3)
+#define MUX_PA14 (DIO | PWM4)
+#define MUX_PA15 (DIO)
+
+#define MUX_PB0 (DIO | PWM0 | _SPI_MISO)    // LED_BUILTIN_1
+#define MUX_PB1 (DIO | PWM1 | _SPI_SCK)     // LED_BUILTIN_2
+#define MUX_PB2 (DIO | PWM2 | _SPI_SCK)     // LED_BUILTIN_3
+#define MUX_PB3 (DIO | PWM3 | _SPI_MISO)
+#define MUX_PB4 (DIO | _SPI_SS)
+#define MUX_PB5 (DIO | _SPI_MOSI)
+#define MUX_PB6 (DIO)
+#define MUX_PB7 (DIO)
+#define MUX_PB8 (DIO)
+#define MUX_PB9 (DIO)
+#define MUX_PB10 (DIO)
+#define MUX_PB11 (DIO)
+#define MUX_PB12 (DIO | PWM0)
+#define MUX_PB13 (DIO | PWM1)
+#define MUX_PB14 (DIO | PWM2 | _SPI_SS)
+#define MUX_PB15 (DIO | PWM3 | _SPI_SCK)
+#define MUX_PB16 (DIO | _SPI_MISO)
+#define MUX_PB17 (DIO | _SPI_MOSI)
+#define MUX_PB18 (DIO)
+#define MUX_PB19 (NONE) // TX0: used to download firmware and output to console
+#define MUX_PB20 (NONE) // RX0: debug data via printf()
+#define MUX_PB21 (DIO)
+#define MUX_PB22 (DIO)
+#define MUX_PB23 (NONE)                     // no pin for PB23 on W806 package
+#define MUX_PB24 (DIO | PWM2 | _SPI_SCK)
+#define MUX_PB25 (DIO | PWM3 | _SPI_MISO)
+#define MUX_PB26 (DIO | PWM4 | _SPI_MOSI)
+#define MUX_PB27 (DIO)
+
+extern const PIN_MAP pin_Map[];
 
 // Additional board settings
 #include "variant.h"

--- a/variants/w806/pins_arduino.h
+++ b/variants/w806/pins_arduino.h
@@ -13,11 +13,14 @@ enum pins
   PB16,PB17,PB18,PB19,PB20,PB21,PB22,PB23,PB24,PB25,PB26,PB27
 };
 
-// Arduino style analog inputs
-#define A0  PA1
-#define A1  PA4
-#define A2  PA3
-#define A4  PA2
+// Arduino macros for analog inputs
+#define A1 PA1
+#define A2 PA2
+#define A3 PA3
+#define A4 PA4
+
+// add A0 as alias to A1 for compatibility
+#define A0 A1
 
 // pin mux macros for W806
 #define MUX_PA0 (DIO | PWM2 | _SPI_SS)      // Boot

--- a/variants/w806/variant.h
+++ b/variants/w806/variant.h
@@ -11,9 +11,8 @@
 #define PIN_SPI_MISO  (PB16)
 #define PIN_SPI_MOSI  (PB17)
 
+#define PINS_COUNT  (44U) // pins in total, PB19, PB20 and PB23 are not used
+#define ADC_COUNT   (4U)  // number of ADC channels
+#define PWM_COUNT   (5U)  // number of PWM channels
 
-#define PINS_COUNT          (44U)           // Количество выводов на плате. Выводы PB19,PB20,PB23 не используются
-#define ADC_COUNT           (4U)            // Количество каналов АЦП
-#define PWM_COUNT           (5U)            // Количество каналов ШИМ
-
-#endif /* _VARIANT_ARDUINO_Air103_ */
+#endif /* _VARIANT_ARDUINO_W806_ */


### PR DESCRIPTION
There is a linker error when trying to compile projects with not only an .ino but also .c and .cpp files.
"multiple definition of `pin_Map'"

And the cause for this is that pins_arduino.h for has this in it:
const PIN_MAP pin_Map[] = {
    { GPIOA, GPIO_PIN_0,	PA0,	DIO|PWM2|_SPI_SS},
    { GPIOA, GPIO_PIN_1,	PA1,	DIO|ADC1|PWM3},	// JTAG_CK
...

As this is an declaration of a variable you end up with multiple copes of pin_Map across the object files.

This pull request fixes the issue by moving the declaration of pin_Map to Arduino.c.

This project did not link before the fix and not it does build for W801, W806 and Air103:
[EVE_HelloWorld_Arduino_IDE.zip](https://github.com/board707/w80x_arduino/files/12267180/EVE_HelloWorld_Arduino_IDE.zip)

It may not work though, but that is something for me to explore, now that it builds.