### PR TITLE
Update variant.h for be blink-friendly

### DIFF
--- a/variants/w806/variant.h
+++ b/variants/w806/variant.h
@@ -4,6 +4,7 @@
 #define LED_BUILTIN_1 PB0
 #define LED_BUILTIN_2 PB1
 #define LED_BUILTIN_3 PB2
+#define LED_BUILTIN LED_BUILTIN_1
 
 // SPI
 #define PIN_SPI_SS    (PB14) 


### PR DESCRIPTION
Just after install w80x board package I could'nt make the standart blink program compile due to LED_BUILTIN undefinition.

To make this user friendly, I'm adding LED_BUILTIN definition.