### PR TITLE
Update variant.h for be blink-friendly

### DIFF
--- a/variants/w801/variant.h
+++ b/variants/w801/variant.h
@@ -8,6 +8,7 @@
 #define LED_BUILTIN_5 PB17
 #define LED_BUILTIN_6 PB16
 #define LED_BUILTIN_7 PB11
+#define LED_BUILTIN LED_BUILTIN_1
 
 // SPI
 #define PIN_SPI_SS    (PB14) 


### PR DESCRIPTION
Just after install w80x board package I could'nt make the standart blink program compile due to LED_BUILTIN undefinition.

To make this user friendly, I'm adding LED_BUILTIN definition.